### PR TITLE
fix: use root crontab for deployment automation

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -280,12 +280,14 @@ Available variables:
 
 ### Cron Job Management
 
-```bash
-# View current cron jobs
-crontab -u ec2-user -l
+The deployment cron job runs under **root's crontab** (since deploy.sh requires sudo to restart services).
 
-# Edit cron jobs
-crontab -u ec2-user -e
+```bash
+# View current cron jobs (as root)
+sudo crontab -l
+
+# Edit cron jobs (as root)
+sudo crontab -e
 
 # Disable automated deployments (comment out the line)
 # 0 * * * * /opt/sso-notifier/deploy.sh >> /opt/sso-notifier/deployment.log 2>&1
@@ -382,8 +384,8 @@ sudo systemctl disable sso-notifier.service
 sudo rm /etc/systemd/system/sso-notifier.service
 sudo systemctl daemon-reload
 
-# Remove cron job
-crontab -u ec2-user -l | grep -v "sso-notifier" | crontab -u ec2-user -
+# Remove cron job (from root's crontab)
+sudo crontab -l | grep -v "sso-notifier" | sudo crontab -
 
 # Remove installation directory
 sudo rm -rf /opt/sso-notifier

--- a/deployment/setup-ec2.sh
+++ b/deployment/setup-ec2.sh
@@ -73,11 +73,11 @@ echo ""
 echo -e "${GREEN}[6/7] Setting up automated deployment cron job...${NC}"
 
 # Check if cron job already exists
-if crontab -u ec2-user -l 2>/dev/null | grep -q "${INSTALL_DIR}/deploy.sh"; then
+if crontab -l 2>/dev/null | grep -q "${INSTALL_DIR}/deploy.sh"; then
     echo "Cron job already exists, skipping..."
 else
-    # Add cron job to check for updates every hour
-    (crontab -u ec2-user -l 2>/dev/null; echo "0 * * * * ${INSTALL_DIR}/deploy.sh >> ${INSTALL_DIR}/deployment.log 2>&1") | crontab -u ec2-user -
+    # Add cron job to check for updates every hour (runs as root since deploy.sh needs sudo)
+    (crontab -l 2>/dev/null; echo "0 * * * * ${INSTALL_DIR}/deploy.sh >> ${INSTALL_DIR}/deployment.log 2>&1") | crontab -
     echo "✓ Cron job added (runs hourly)"
 fi
 


### PR DESCRIPTION
## Issue

The deployment cron job was being added to ec2-user's crontab, but `deploy.sh` requires root privileges to restart systemd services. This would cause the automated deployments to fail.

## Root Cause

When comparing with english-learning-bot, I noticed it uses `crontab -` (which adds to root's crontab when script runs as root), while we were using `crontab -u ec2-user -`.

Since `deploy.sh` checks for root privileges (`if [ "$EUID" -ne 0 ]`) and needs sudo to run `systemctl stop/start`, the cron job must run as root.

## Changes

**setup-ec2.sh:**
- ✅ Changed from `crontab -u ec2-user` to `crontab` (runs as root)
- ✅ Added comment explaining why it needs root

**deployment/README.md:**
- ✅ Added note that cron runs under root's crontab
- ✅ Updated cron management commands to use `sudo crontab`
- ✅ Updated uninstallation instructions to remove from root's crontab

## Testing

After merging, verify cron job is in root's crontab:
```bash
sudo crontab -l | grep deploy.sh
```

Should show:
```
0 * * * * /opt/sso-notifier/deploy.sh >> /opt/sso-notifier/deployment.log 2>&1
```

## Related

Follow-up to #13 and #14 - aligns with english-learning-bot deployment pattern