### PR TITLE
refactor: remove automatic deployments and enable manual control

### DIFF
--- a/deployment/sudoers.d/sso-notifier
+++ b/deployment/sudoers.d/sso-notifier
@@ -1,0 +1,6 @@
+# Allow ec2-user to manage sso-notifier service without password
+ec2-user ALL=(ALL) NOPASSWD: /bin/systemctl start sso-notifier.service
+ec2-user ALL=(ALL) NOPASSWD: /bin/systemctl stop sso-notifier.service
+ec2-user ALL=(ALL) NOPASSWD: /bin/systemctl restart sso-notifier.service
+ec2-user ALL=(ALL) NOPASSWD: /bin/systemctl status sso-notifier.service
+ec2-user ALL=(ALL) NOPASSWD: /bin/systemctl is-active sso-notifier.service


### PR DESCRIPTION
- Remove cron job setup from deployment automation
- Refactor deploy.sh to run as ec2-user with passwordless sudo
- Add sudoers configuration for scoped systemctl permissions
- Update documentation to reflect manual deployment approach
- Improve security by requiring explicit deployment execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)