### PR TITLE
ci: pin security scan actions to commit SHAs, drop unpinned tool installs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       # Initializes the CodeQL tools for scanning
       - name: Initialize CodeQL

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -24,15 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26.5"
+        uses: actions/checkout@v7
 
       - name: Run gosec Security Scanner
-        uses: securego/gosec@v2.26.1
+        uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
         with:
           args: "-no-fail -fmt sarif -out gosec-results.sarif -exclude-generated -severity high ./..."
 
@@ -44,9 +39,9 @@ jobs:
 
       - name: Run gosec with detailed output
         if: always()
-        run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
-          gosec -exclude-generated -confidence medium -severity medium -fmt=json -out=gosec-report.json ./... || true
+        uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
+        with:
+          args: "-no-fail -exclude-generated -confidence medium -severity medium -fmt=json -out=gosec-report.json ./..."
 
       - name: Upload gosec report
         if: always()

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
-          go-version-input: "1.26.5"
+          go-version-input: "1.26.6"
 
       - name: Report vulnerabilities
         if: failure()

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -24,18 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26.5"
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        uses: actions/checkout@v7
 
       - name: Run govulncheck
-        run: govulncheck ./...
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-input: "1.26.5"
 
       - name: Report vulnerabilities
         if: failure()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Roma7-7-7/sso-notifier
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0


### PR DESCRIPTION
Mirrors the hardening from Roma7-7-7/english-learning-bot@fb7d550: gosec.yaml and govulncheck.yaml both ran `go install .../pkg@latest` before invoking the tool, which is vulnerable to tag-pointer attacks and non-reproducible builds.

- gosec.yaml: drop redundant Setup Go step (gosec action is a self-contained Docker action); pin securego/gosec to its v2.28.0 commit SHA for both the SARIF scan and the detailed JSON report step, replacing the manual `go install gosec@latest` run
- govulncheck.yaml: drop Setup Go and manual `go install govulncheck@latest`; use the official golang/govulncheck-action pinned to its v1.1.0 commit SHA, with go-version-input matching go.mod (1.26.5)
- bump actions/checkout v6 -> v7 in both workflows

Dockerfile has no npm/node stage, so the --ignore-scripts part of the referenced fix doesn't apply here.